### PR TITLE
Avoid child process

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -19,4 +19,4 @@ hooks:
 # The configuration of the application when it is exposed to the web.
 web:
     commands:
-        start: yarn start -p $PORT
+        start: npx next start -p $PORT


### PR DESCRIPTION
I noticed that when "Redeploy" button is used, it restart only the main process, not the children process. It means that it will restart `yarn start`, not `next start`.