### PR TITLE
Add .next/cache as mount so images can be resized

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -20,3 +20,9 @@ hooks:
 web:
     commands:
         start: npx next start -p $PORT
+
+mounts:
+    # Next.js will try to cache files, so it must be writeable.
+    '/.next/cache':
+        source: local
+        source_path: '.next/cache'


### PR DESCRIPTION
We figured out that the the [image optimization](https://nextjs.org/docs/basic-features/image-optimization) feature of Next.js doesn't work on Platform.sh environment (but it was working on local machines) so the fix is simply to add the `.next/cache` folder as mount here 🤗  