### PR TITLE
Fix issue #62

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -8,7 +8,7 @@ type: 'nodejs:14'
 
 dependencies:
     nodejs:
-        yarn: "^1.22.0"
+        yarn: '^1.22.0'
 
 # The hooks that will be triggered when the package is deployed.
 hooks:
@@ -27,6 +27,9 @@ hooks:
     deploy: |
         # Move committed files from temp directory back into mounts.
         ./handle_mounts.sh
+        # On consecutive builds the server was already started before the new files were copied,
+        # so kill the process so that it automatically restarts with the new files
+        kill -9 $(lsof -t -i:$PORT)
 
 # The configuration of the application when it is exposed to the web.
 web:
@@ -44,7 +47,7 @@ mounts:
         source_path: 'next'
 
 source:
-  operations:
-    auto-update:
-      command: |
-        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+    operations:
+        auto-update:
+            command: |
+                curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0


### PR DESCRIPTION
## Description
Because the files from the temporary directory are copied after the process has been started (in the deploy hook), the process starts based on the wrong files. My hypothesis is that the very first time this doesn't cause issues as the process will crash (because there's no build folder), and an automatic restart will fix the situation. However, with an existing build the process will not crash and there will be inconsistencies between the process and the build folder. The proposed fix is to kill the process in the deploy hook after the files have been copied, so an automatic restart will cause the process the start with the new build folder. 

## Related Issue
https://github.com/platformsh-templates/nextjs/issues/62

## How Has This Been Tested?
I tested it in a clean environment with consecutive builds

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
