### PR TITLE
Update sourceops.yaml

### DIFF
--- a/.github/workflows/sourceops.yaml
+++ b/.github/workflows/sourceops.yaml
@@ -37,7 +37,7 @@ jobs:
 
           projIDpttrn='\/projects\/([^\/]+)\/integrations'
           if [[ "${integrationURL}" =~ ${projIDpttrn} ]]; then
-               echo "PLATFORMSH_PROJECT=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+               echo "PLATFORM_PROJECT=${BASH_REMATCH[1]}" >> $GITHUB_ENV
                echo "::notice::Project ID is ${BASH_REMATCH[1]}"
                #echo "::set-output name=projectID::${BASH_REMATCH[1]}"
           else


### PR DESCRIPTION
## Description
correct env var name from PLATFORMSH_PROJECT --> PLATFORM_PROJECT

## Related Issue
Workflow fails to run due to incorrect env var name

### Please drop a link to the issue here:
https://github.com/platformsh-templates/nextjs/actions/runs/4039765211/jobs/6944802888#step:6:35

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the contribution guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
